### PR TITLE
sparse,src/sparse/array/csc: add the image optimization to CSC SpMV

### DIFF
--- a/sparse/csc.py
+++ b/sparse/csc.py
@@ -379,7 +379,9 @@ class csc_array(CompressedBase, DenseSparseBase):
                     # Squeeze out here so that we can do a direct
                     # assignment later.
                     out = out.squeeze(1)
-                    result = store_to_cunumeric_array(ctx.create_store(A.dtype, shape=(self.shape[0],)))
+                    result = store_to_cunumeric_array(
+                        ctx.create_store(A.dtype, shape=(self.shape[0],))
+                    )
                 else:
                     assert out.shape == (self.shape[0],)
                 result.fill(0)

--- a/src/sparse/array/csc/spmv.cu
+++ b/src/sparse/array/csc/spmv.cu
@@ -36,7 +36,7 @@ struct CSCSpMVColSplitImpl<VariantKind::GPU> {
     auto& x      = args.x;
 
     // Break out early if the iteration space partition is empty.
-    if (x.domain().empty()) return;
+    if (x.domain().empty() || A_crd.domain().empty() || y.domain().empty()) return;
 
     // Get context sensitive objects.
     auto handle = get_cusparse();
@@ -44,7 +44,18 @@ struct CSCSpMVColSplitImpl<VariantKind::GPU> {
     CHECK_CUSPARSE(cusparseSetStream(handle, stream));
 
     // Construct the CUSPARSE objects from individual regions.
-    auto cusparse_y = makeCuSparseDenseVec<VAL_TY>(y);
+    // The image optimization has been applied to y, so use a similar
+    // dense vector construction method as the CSR SpMV routine. See
+    // the comments there for more details about what is being done.
+    auto y_domain = y.domain();
+    auto rows     = y_domain.hi()[0] + 1;
+    auto y_raw_ptr =
+      y.reduce_accessor<SumReduction<VAL_TY>, true /* exclusive */, 1>().ptr(y_domain.lo());
+    auto y_ptr = y_raw_ptr - static_cast<size_t>(y_domain.lo()[0]);
+    cusparseDnVecDescr_t cusparse_y;
+    CHECK_CUSPARSE(cusparseCreateDnVec(
+      &cusparse_y, rows, const_cast<VAL_TY*>(x_ptr), cusparseDataType<VAL_TY>()));
+    // Use the standard construction methods for the other operands.
     auto cusparse_x = makeCuSparseDenseVec<VAL_TY>(x);
     auto cusparse_A =
       makeCuSparseCSC<INDEX_TY, VAL_TY>(A_pos, A_crd, A_vals, y.domain().get_volume() /* rows */);

--- a/src/sparse/array/csc/spmv.cu
+++ b/src/sparse/array/csc/spmv.cu
@@ -57,12 +57,11 @@ struct CSCSpMVColSplitImpl<VariantKind::GPU> {
       &cusparse_y, rows, const_cast<VAL_TY*>(y_ptr), cusparseDataType<VAL_TY>()));
     // Use the standard construction methods for the other operands.
     auto cusparse_x = makeCuSparseDenseVec<VAL_TY>(x);
-    auto cusparse_A =
-      makeCuSparseCSC<INDEX_TY, VAL_TY>(A_pos, A_crd, A_vals, rows);
+    auto cusparse_A = makeCuSparseCSC<INDEX_TY, VAL_TY>(A_pos, A_crd, A_vals, rows);
 
     // Make the CUSPARSE calls.
-    VAL_TY alpha   = 1.0;
-    // This is very subtle but we actually want to set beta=1.0 here 
+    VAL_TY alpha = 1.0;
+    // This is very subtle but we actually want to set beta=1.0 here
     // rather than 0.0. If beta=0, then cuSPARSE will try to initialize
     // the full output vector to 0, which will write into out-of-bounds
     // memory locations, leading either to segfaults or silent corruption

--- a/src/sparse/array/csc/spmv.cu
+++ b/src/sparse/array/csc/spmv.cu
@@ -54,15 +54,22 @@ struct CSCSpMVColSplitImpl<VariantKind::GPU> {
     auto y_ptr = y_raw_ptr - static_cast<size_t>(y_domain.lo()[0]);
     cusparseDnVecDescr_t cusparse_y;
     CHECK_CUSPARSE(cusparseCreateDnVec(
-      &cusparse_y, rows, const_cast<VAL_TY*>(x_ptr), cusparseDataType<VAL_TY>()));
+      &cusparse_y, rows, const_cast<VAL_TY*>(y_ptr), cusparseDataType<VAL_TY>()));
     // Use the standard construction methods for the other operands.
     auto cusparse_x = makeCuSparseDenseVec<VAL_TY>(x);
     auto cusparse_A =
-      makeCuSparseCSC<INDEX_TY, VAL_TY>(A_pos, A_crd, A_vals, y.domain().get_volume() /* rows */);
+      makeCuSparseCSC<INDEX_TY, VAL_TY>(A_pos, A_crd, A_vals, rows);
 
     // Make the CUSPARSE calls.
     VAL_TY alpha   = 1.0;
-    VAL_TY beta    = 0.0;
+    // This is very subtle but we actually want to set beta=1.0 here 
+    // rather than 0.0. If beta=0, then cuSPARSE will try to initialize
+    // the full output vector to 0, which will write into out-of-bounds
+    // memory locations, leading either to segfaults or silent corruption
+    // of other instance's data. By setting beta=1.0 and handling output
+    // initialization on the legate side, we can restrict the kernel to
+    // writing into only the locations referenced by A's coordinates.
+    VAL_TY beta    = 1.0;
     size_t bufSize = 0;
     CHECK_CUSPARSE(cusparseSpMV_bufferSize(handle,
                                            CUSPARSE_OPERATION_NON_TRANSPOSE,


### PR DESCRIPTION
Uses the image optimization for better scalability and memory usage for CSC SpMV operations.

Fixes #8.

Signed-off-by: Rohan Yadav <rohany@alumni.cmu.edu>