### PR TITLE
sparse: make use of precise images controllable via a command line flag

### DIFF
--- a/sparse/partition.py
+++ b/sparse/partition.py
@@ -142,6 +142,16 @@ class MinMaxImagePartition(ImagePartition):
         color_shape: Optional[Shape] = None,
         color_transform: Optional[Transform] = None,
     ) -> Optional[LegionPartition]:
+        # If we've been requested to compute precise images,
+        # then fall back to the standard ImagePartition.
+        if sparse_runtime.args.precise_images:
+            return super().construct(
+                region,
+                complete=complete,
+                color_shape=color_shape,
+                color_transform=color_transform,
+            )
+
         assert len(self._store.shape) == 1 and not self._range
         index_partition = runtime.partition_manager.find_index_partition(
             region.index_space, self

--- a/sparse/runtime.py
+++ b/sparse/runtime.py
@@ -16,6 +16,7 @@ import os
 
 import numpy as np
 from legate.core import Rect, get_legate_runtime, types
+from legate.rc import ArgSpec, Argument, parse_command_args
 
 from .config import (
     SparseOpCode,
@@ -25,6 +26,21 @@ from .config import (
     _supported_dtypes,
     sparse_ctx,
 )
+
+ARGS = [
+    Argument(
+        "precise-images",
+        ArgSpec(
+            action="store_true",
+            default=False,
+            dest="precise_images",
+            help="Use precise images instead of approximate min-max "
+            "boundary based images. This can potentially reduce "
+            "communication volume at the cost of increasing "
+            "startup time before application steady state.",
+        ),
+    ),
+]
 
 
 class Runtime:
@@ -74,6 +90,9 @@ class Runtime:
             self.legate_runtime.get_nccl_communicator().initialize(
                 self.num_gpus
             )
+
+        # Parse legate.sparse specific command line arguments.
+        self.args = parse_command_args("legate_sparse", ARGS)
 
     def get_1d_to_2d_functor_id(self, xdim: int, ydim: int, rows: bool) -> int:
         key = (xdim, ydim, rows)


### PR DESCRIPTION
Fixes #70.

Signed-off-by: Rohan Yadav <rohany@alumni.cmu.edu>