### PR TITLE
sparse,src/sparse/linalg: refactor AXPBY to avoid h-to-d future copies

### DIFF
--- a/sparse/linalg.py
+++ b/sparse/linalg.py
@@ -481,11 +481,13 @@ def axpby(y, x, alpha=None, beta=None):
         alpha_store = get_store_from_cunumeric_array(alpha, allow_future=True)
         task.add_input(alpha_store)
         task.add_scalar_arg(True, bool)
+        task.add_broadcast(alpha_store)
     elif beta is not None:
         assert isinstance(beta, np.ndarray) and beta.size == 1
         beta_store = get_store_from_cunumeric_array(beta, allow_future=True)
         task.add_input(beta_store)
         task.add_scalar_arg(False, bool)
+        task.add_broadcast(beta_store)
     assert not (alpha is not None and beta is not None)
     task.add_input(y_store)
     task.add_alignment(y_store, x_store)

--- a/src/sparse/linalg/axpby.cc
+++ b/src/sparse/linalg/axpby.cc
@@ -22,18 +22,21 @@ namespace sparse {
 using namespace Legion;
 using namespace legate;
 
-template <LegateTypeCode VAL_CODE>
-struct AXPBYImplBody<VariantKind::CPU, VAL_CODE> {
+template <LegateTypeCode VAL_CODE, bool IS_ALPHA>
+struct AXPBYImplBody<VariantKind::CPU, VAL_CODE, IS_ALPHA> {
   using VAL_TY = legate_type_of<VAL_CODE>;
 
   void operator()(const AccessorRW<VAL_TY, 1>& y,
                   const AccessorRO<VAL_TY, 1>& x,
-                  const AccessorRO<VAL_TY, 1>& alpha,
-                  const AccessorRO<VAL_TY, 1>& beta,
+                  const AccessorRO<VAL_TY, 1>& alphabeta,
                   const Rect<1>& rect)
   {
     for (coord_t i = rect.lo[0]; i < rect.hi[0] + 1; i++) {
-      y[i] = alpha[0] * x[i] + beta[0] * y[i];
+      if (IS_ALPHA) {
+        y[i] = alphabeta[0] * x[i] + y[i];
+      } else {
+        y[i] = x[i] + alphabeta[0] * y[i];
+      }
     }
   }
 };

--- a/src/sparse/linalg/axpby.cu
+++ b/src/sparse/linalg/axpby.cu
@@ -53,7 +53,7 @@ struct AXPBYImplBody<VariantKind::GPU, VAL_CODE, IS_ALPHA> {
     auto blocks = get_num_blocks_1d(elems);
     auto stream = get_cached_stream();
     axpby_kernel<VAL_TY, IS_ALPHA>
-      <<<blocks, THREADS_PER_BLOCK, 0, stream>>>(elems, rect.lo[0], y, x, alpha);
+      <<<blocks, THREADS_PER_BLOCK, 0, stream>>>(elems, rect.lo[0], y, x, alphabeta);
     CHECK_CUDA_STREAM(stream);
   }
 };

--- a/src/sparse/linalg/axpby.cu
+++ b/src/sparse/linalg/axpby.cu
@@ -23,34 +23,37 @@ namespace sparse {
 using namespace Legion;
 using namespace legate;
 
-template <typename VAL_TY>
+template <typename VAL_TY, bool IS_ALPHA>
 __global__ void axpby_kernel(size_t elems,
                              coord_t offset,
                              AccessorRW<VAL_TY, 1> y,
                              AccessorRO<VAL_TY, 1> x,
-                             AccessorRO<VAL_TY, 1> alpha,
-                             AccessorRO<VAL_TY, 1> beta)
+                             AccessorRO<VAL_TY, 1> alphabeta)
 {
   const auto idx = global_tid_1d();
   if (idx >= elems) return;
   auto i = idx + offset;
-  y[i]   = alpha[0] * x[i] + beta[0] * y[i];
+  if (IS_ALPHA) {
+    y[i] = alphabeta[0] * x[i] + y[i];
+  } else {
+    y[i] = x[i] + alphabeta[0] * y[i];
+  }
 }
 
-template <LegateTypeCode VAL_CODE>
-struct AXPBYImplBody<VariantKind::GPU, VAL_CODE> {
+template <LegateTypeCode VAL_CODE, bool IS_ALPHA>
+struct AXPBYImplBody<VariantKind::GPU, VAL_CODE, IS_ALPHA> {
   using VAL_TY = legate_type_of<VAL_CODE>;
 
   void operator()(const AccessorRW<VAL_TY, 1>& y,
                   const AccessorRO<VAL_TY, 1>& x,
-                  const AccessorRO<VAL_TY, 1>& alpha,
-                  const AccessorRO<VAL_TY, 1>& beta,
+                  const AccessorRO<VAL_TY, 1>& alphabeta,
                   const Rect<1>& rect)
   {
     auto elems  = rect.volume();
     auto blocks = get_num_blocks_1d(elems);
     auto stream = get_cached_stream();
-    axpby_kernel<<<blocks, THREADS_PER_BLOCK, 0, stream>>>(elems, rect.lo[0], y, x, alpha, beta);
+    axpby_kernel<VAL_TY, IS_ALPHA>
+      <<<blocks, THREADS_PER_BLOCK, 0, stream>>>(elems, rect.lo[0], y, x, alpha);
     CHECK_CUDA_STREAM(stream);
   }
 };

--- a/src/sparse/linalg/axpby.h
+++ b/src/sparse/linalg/axpby.h
@@ -25,8 +25,8 @@ namespace sparse {
 struct AXPBYArgs {
   const legate::Store& y;
   const legate::Store& x;
-  const legate::Store& alpha;
-  const legate::Store& beta;
+  const legate::Store& alphabeta;
+  const bool isalpha;
 };
 
 class AXPBY : public SparseTask<AXPBY> {

--- a/src/sparse/linalg/axpby_omp.cc
+++ b/src/sparse/linalg/axpby_omp.cc
@@ -22,19 +22,22 @@ namespace sparse {
 using namespace Legion;
 using namespace legate;
 
-template <LegateTypeCode VAL_CODE>
-struct AXPBYImplBody<VariantKind::OMP, VAL_CODE> {
+template <LegateTypeCode VAL_CODE, bool IS_ALPHA>
+struct AXPBYImplBody<VariantKind::OMP, VAL_CODE, IS_ALPHA> {
   using VAL_TY = legate_type_of<VAL_CODE>;
 
   void operator()(const AccessorRW<VAL_TY, 1>& y,
                   const AccessorRO<VAL_TY, 1>& x,
-                  const AccessorRO<VAL_TY, 1>& alpha,
-                  const AccessorRO<VAL_TY, 1>& beta,
+                  const AccessorRO<VAL_TY, 1>& alphabeta,
                   const Rect<1>& rect)
   {
 #pragma omp parallel for schedule(static)
     for (coord_t i = rect.lo[0]; i < rect.hi[0] + 1; i++) {
-      y[i] = alpha[0] * x[i] + beta[0] * y[i];
+      if (IS_ALPHA) {
+        y[i] = alphabeta[0] * x[i] + y[i];
+      } else {
+        y[i] = x[i] + alphabeta[0] * y[i];
+      }
     }
   }
 };


### PR DESCRIPTION
Host to device future copies on critical paths have been known to cause severe performance degradation within the cuda driver. This commit refactors the AXPBY task to avoid creating futures that will then be copied from host memory into device memory.

Signed-off-by: Rohan Yadav <rohany@alumni.cmu.edu>