### PR TITLE
examples: refactor benchmarks and timing infrastructure

### DIFF
--- a/examples/benchmark.py
+++ b/examples/benchmark.py
@@ -1,0 +1,100 @@
+import argparse
+
+from typing_extensions import Protocol
+
+
+class Timer(Protocol):
+    def start(self):
+        ...
+
+    def stop(self):
+        """
+        Blocks execution until everything before it has completed. Returns the
+        duration since the last call to start(), in milliseconds.
+        """
+        ...
+
+
+class LegateTimer(Timer):
+    def __init__(self):
+        self._start_future = None
+
+    def start(self):
+        from legate.timing import time
+
+        self._start_future = time()
+
+    def stop(self):
+        from legate.timing import time
+
+        end_future = time()
+        return (end_future - self._start_future) / 1000.0
+
+
+class CuPyTimer(Timer):
+    def __init__(self):
+        self._start_event = None
+
+    def start(self):
+        from cupy import cuda
+
+        self._start_event = cuda.Event()
+        self._start_event.record()
+
+    def stop(self):
+        from cupy import cuda
+
+        end_event = cuda.Event()
+        end_event.record()
+        end_event.synchronize()
+        return cuda.get_elapsed_time(self._start_event, end_event)
+
+
+class NumPyTimer(Timer):
+    def __init__(self):
+        self._start_time = None
+
+    def start(self):
+        from time import perf_counter_ns
+
+        self._start_time = perf_counter_ns() / 1000.0
+
+    def stop(self):
+        from time import perf_counter_ns
+
+        end_time = perf_counter_ns() / 1000.0
+        return (end_time - self._start_time) / 1000.0
+
+
+def parse_common_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "-package",
+        type=str,
+        default="legate",
+        choices=["legate", "cupy", "scipy"],
+    )
+    args, _ = parser.parse_known_args()
+    if args.package == "legate":
+        timer = LegateTimer()
+        import cunumeric as np
+
+        import sparse
+        import sparse.linalg as linalg
+
+        use_legate = True
+    elif args.package == "cupy":
+        timer = CuPyTimer()
+        import cupy as np
+        import cupyx.scipy.sparse as sparse
+        from cupyx.scipy.sparse import linalg
+
+        use_legate = False
+    else:
+        timer = NumPyTimer()
+        import numpy as np
+        import scipy.sparse as sparse
+        from scipy.sparse import linalg
+
+        use_legate = False
+    return args.package, timer, np, sparse, linalg, use_legate

--- a/examples/dot_microbenchmark.py
+++ b/examples/dot_microbenchmark.py
@@ -1,38 +1,17 @@
 import argparse
 
+from benchmark import parse_common_args
+
 parser = argparse.ArgumentParser()
 parser.add_argument("-n", type=int, default=100)
 parser.add_argument("-i", type=int, default=25)
 parser.add_argument("-op", choices=["spmv", "spmm"], default="spmv")
 parser.add_argument("-k", type=int, default=32)
-parser.add_argument(
-    "-package", choices=["legate", "cupy", "scipy"], default="legate"
-)
 args, _ = parser.parse_known_args()
 n = args.n
 iters = args.i
 op = args.op
-
-if args.package == "legate":
-    import cunumeric as np
-    from legate.timing import time
-
-    import sparse
-
-    use_legate = True
-else:
-    from time import perf_counter_ns
-
-    def time():
-        return perf_counter_ns() / 1000.0
-
-    if args.package == "cupy":
-        import cupy as np
-        import cupyx.scipy.sparse as sparse
-    elif args.package == "scipy":
-        import numpy as np
-        import scipy.sparse as sparse
-    use_legate = False
+_, timer, np, sparse, _, use_legate = parse_common_args()
 
 # Create a banded diagonal matrix with 5 diagonals.
 A = sparse.diags(
@@ -61,10 +40,9 @@ def f():
 # Run one to warm up the system.
 f()
 
-start = time()
+timer.start()
 for i in range(iters):
     f()
-end = time()
-total_s = (end - start) / 1000.0 / 1000.0
+total = timer.stop() / 1000.0
 
-print(f"Iterations / sec: {iters / total_s}")
+print(f"Iterations / sec: {iters / total}")

--- a/test.py
+++ b/test.py
@@ -24,6 +24,7 @@ from legate.tester.test_plan import TestPlan
 from legate.tester.test_system import TestSystem
 
 # Add some other tests that we shouldn't run.
+SKIPPED_EXAMPLES.add("examples/benchmark.py")
 SKIPPED_EXAMPLES.add("examples/plot.py")
 SKIPPED_EXAMPLES.add("examples/pyamg_legate_test.py")
 SKIPPED_EXAMPLES.add("examples/reference_amg.py")


### PR DESCRIPTION
This commit adjusts the timing infrastructure in the benchmarks and avoids the branching occurring in each benchmark.

Signed-off-by: Rohan Yadav <rohany@alumni.cmu.edu>