### PR TITLE
sparse,src/sparse/array/csr: fix weak scaling of SpGEMM CSRxCSRxCSR

### DIFF
--- a/sparse/csr.py
+++ b/sparse/csr.py
@@ -1354,7 +1354,6 @@ def spgemm_csr_csr_csr(B: csr_array, C: csr_array) -> csr_array:
             disjoint=False,
             complete=False,
         )
-        task.add_scalar_arg(C.shape[1], types.uint64)
         task.execute()
 
         pos, nnz = CompressedBase.nnz_to_pos_cls(q_nnz)
@@ -1389,7 +1388,6 @@ def spgemm_csr_csr_csr(B: csr_array, C: csr_array) -> csr_array:
         # Add pos to the inputs as well so that we get READ_WRITE
         # privileges.
         task.add_input(pos)
-        task.add_scalar_arg(C.shape[1], types.uint64)
         task.execute()
         return csr_array(
             (vals, crd, pos),

--- a/src/sparse/array/csr/spgemm_csr_csr_csr.h
+++ b/src/sparse/array/csr/spgemm_csr_csr_csr.h
@@ -28,7 +28,6 @@ struct SpGEMMCSRxCSRxCSRNNZArgs {
   const legate::Store& B_crd;
   const legate::Store& C_pos;
   const legate::Store& C_crd;
-  const uint64_t A2_dim;
 };
 
 class SpGEMMCSRxCSRxCSRNNZ : public SparseTask<SpGEMMCSRxCSRxCSRNNZ> {
@@ -50,7 +49,6 @@ struct SpGEMMCSRxCSRxCSRArgs {
   const legate::Store& C_pos;
   const legate::Store& C_crd;
   const legate::Store& C_vals;
-  const uint64_t A2_dim;
 };
 
 class SpGEMMCSRxCSRxCSR : public SparseTask<SpGEMMCSRxCSRxCSR> {

--- a/src/sparse/array/csr/spgemm_csr_csr_csr_omp.cc
+++ b/src/sparse/array/csr/spgemm_csr_csr_csr_omp.cc
@@ -18,6 +18,7 @@
 #include "sparse/array/csr/spgemm_csr_csr_csr_template.inl"
 
 #include <omp.h>
+#include <thrust/extrema.h>
 
 namespace sparse {
 

--- a/src/sparse/array/csr/spgemm_csr_csr_csr_omp.cc
+++ b/src/sparse/array/csr/spgemm_csr_csr_csr_omp.cc
@@ -33,22 +33,37 @@ struct SpGEMMCSRxCSRxCSRNNZImplBody<VariantKind::OMP, INDEX_CODE> {
                   const AccessorRO<INDEX_TY, 1>& B_crd,
                   const AccessorRO<Rect<1>, 1>& C_pos,
                   const AccessorRO<INDEX_TY, 1>& C_crd,
-                  const uint64_t A2_dim,
-                  const Rect<1>& rect)
+                  const Rect<1>& rect,
+                  const Rect<1>& C_crd_bounds)
   {
-    INDEX_TY initCoord = static_cast<INDEX_TY>(0);
-    bool initBool      = false;
-    auto num_threads   = omp_get_max_threads();
-    auto kind          = Sparse::has_numamem ? Memory::SOCKET_MEM : Memory::SYSTEM_MEM;
-    DeferredBuffer<INDEX_TY, 1> index_list_all(
-      kind, Rect<1>{0, (A2_dim * num_threads) - 1}, &initCoord);
-    DeferredBuffer<bool, 1> already_set_all(
-      kind, Rect<1>{0, (A2_dim * num_threads) - 1}, &initBool);
+    auto num_threads = omp_get_max_threads();
+    auto kind        = Sparse::has_numamem ? Memory::SOCKET_MEM : Memory::SYSTEM_MEM;
+
+    // Calculate A2_dim by looking at the min and max coordinates in
+    // the provided partition of C.
+    auto C_crd_ptr = C_crd.ptr(C_crd_bounds.lo);
+    auto result =
+      thrust::minmax_element(thrust::omp::par, C_crd_ptr, C_crd_ptr + C_crd_bounds.volume());
+    INDEX_TY min    = *result.first;
+    INDEX_TY max    = *result.second;
+    INDEX_TY A2_dim = max - min + 1;
+
+    // Next, initialize the deferred buffers ourselves, instead of using
+    // Realm fills (which tend to be slower).
+    DeferredBuffer<INDEX_TY, 1> index_list_all(kind, Rect<1>{0, (A2_dim * num_threads) - 1});
+    DeferredBuffer<bool, 1> already_set_all(kind, Rect<1>{0, (A2_dim * num_threads) - 1});
+#pragma omp parallel for schedule(static)
+    for (INDEX_TY i = 0; i < A2_dim * num_threads; i++) {
+      index_list_all[i]  = 0;
+      already_set_all[i] = false;
+    }
+
 #pragma omp parallel for schedule(monotonic : dynamic, 128)
     for (auto i = rect.lo[0]; i < rect.hi[0] + 1; i++) {
-      auto thread_id         = omp_get_thread_num();
-      auto index_list        = index_list_all.ptr(thread_id * A2_dim);
-      auto already_set       = already_set_all.ptr(thread_id * A2_dim);
+      auto thread_id = omp_get_thread_num();
+      // Offset each accessed array by the min coordinate.
+      auto index_list        = index_list_all.ptr(thread_id * A2_dim) - min;
+      auto already_set       = already_set_all.ptr(thread_id * A2_dim) - min;
       size_t index_list_size = 0;
       for (size_t kB = B_pos[i].lo; kB < B_pos[i].hi + 1; kB++) {
         auto k = B_crd[kB];
@@ -86,26 +101,41 @@ struct SpGEMMCSRxCSRxCSRImplBody<VariantKind::OMP, INDEX_CODE, VAL_CODE> {
                   const AccessorRO<Rect<1>, 1>& C_pos,
                   const AccessorRO<INDEX_TY, 1>& C_crd,
                   const AccessorRO<VAL_TY, 1>& C_vals,
-                  const uint64_t A2_dim,
-                  const Rect<1>& rect)
+                  const Rect<1>& rect,
+                  const Rect<1>& C_crd_bounds)
   {
-    INDEX_TY initCoord = static_cast<INDEX_TY>(0);
-    bool initBool      = false;
-    VAL_TY initVal     = static_cast<VAL_TY>(0);
-    auto num_threads   = omp_get_max_threads();
-    auto kind          = Sparse::has_numamem ? Memory::SOCKET_MEM : Memory::SYSTEM_MEM;
-    DeferredBuffer<INDEX_TY, 1> index_list_all(
-      kind, Rect<1>{0, (A2_dim * num_threads) - 1}, &initCoord);
-    DeferredBuffer<bool, 1> already_set_all(
-      kind, Rect<1>{0, (A2_dim * num_threads) - 1}, &initBool);
-    DeferredBuffer<VAL_TY, 1> workspace_all(kind, Rect<1>{0, (A2_dim * num_threads) - 1}, &initVal);
+    auto num_threads = omp_get_max_threads();
+    auto kind        = Sparse::has_numamem ? Memory::SOCKET_MEM : Memory::SYSTEM_MEM;
+
+    // Calculate A2_dim by looking at the min and max coordinates in
+    // the provided partition of C.
+    auto C_crd_ptr = C_crd.ptr(C_crd_bounds.lo);
+    auto result =
+      thrust::minmax_element(thrust::omp::par, C_crd_ptr, C_crd_ptr + C_crd_bounds.volume());
+    INDEX_TY min    = *result.first;
+    INDEX_TY max    = *result.second;
+    INDEX_TY A2_dim = max - min + 1;
+
+    // Next, initialize the deferred buffers ourselves, instead of using
+    // Realm fills (which tend to be slower).
+    DeferredBuffer<INDEX_TY, 1> index_list_all(kind, Rect<1>{0, (A2_dim * num_threads) - 1});
+    DeferredBuffer<bool, 1> already_set_all(kind, Rect<1>{0, (A2_dim * num_threads) - 1});
+    DeferredBuffer<VAL_TY, 1> workspace_all(kind, Rect<1>{0, (A2_dim * num_threads) - 1});
+#pragma omp parallel for schedule(static)
+    for (INDEX_TY i = 0; i < A2_dim * num_threads; i++) {
+      index_list_all[i]  = 0;
+      already_set_all[i] = false;
+      workspace_all[i]   = 0;
+    }
+
     // For this computation, we assume that the rows are partitioned.
 #pragma omp parallel for schedule(monotonic : dynamic, 128)
     for (auto i = rect.lo[0]; i < rect.hi[0] + 1; i++) {
-      auto thread_id         = omp_get_thread_num();
-      auto index_list        = index_list_all.ptr(thread_id * A2_dim);
-      auto already_set       = already_set_all.ptr(thread_id * A2_dim);
-      auto workspace         = workspace_all.ptr(thread_id * A2_dim);
+      auto thread_id = omp_get_thread_num();
+      // Back offset each of the pointers by the min element.
+      auto index_list        = index_list_all.ptr(thread_id * A2_dim) - min;
+      auto already_set       = already_set_all.ptr(thread_id * A2_dim) - min;
+      auto workspace         = workspace_all.ptr(thread_id * A2_dim) - min;
       size_t index_list_size = 0;
       for (size_t kB = B_pos[i].lo; kB < B_pos[i].hi + 1; kB++) {
         auto k = B_crd[kB];

--- a/src/sparse/array/csr/spgemm_csr_csr_csr_template.inl
+++ b/src/sparse/array/csr/spgemm_csr_csr_csr_template.inl
@@ -43,7 +43,7 @@ struct SpGEMMCSRxCSRxCSRNNZImpl {
     auto C_crd = args.C_crd.read_accessor<INDEX_TY, 1>();
 
     SpGEMMCSRxCSRxCSRNNZImplBody<KIND, INDEX_CODE>()(
-      nnz, B_pos, B_crd, C_pos, C_crd, args.A2_dim, args.B_pos.shape<1>());
+      nnz, B_pos, B_crd, C_pos, C_crd, args.B_pos.shape<1>(), args.C_crd.shape<1>());
   }
 };
 
@@ -77,8 +77,8 @@ struct SpGEMMCSRxCSRxCSRImpl {
                                                             C_pos,
                                                             C_crd,
                                                             C_vals,
-                                                            args.A2_dim,
-                                                            args.B_pos.shape<1>());
+                                                            args.B_pos.shape<1>(),
+                                                            args.C_crd.shape<1>());
   }
 };
 
@@ -92,7 +92,6 @@ static void spgemm_csr_csr_csr_nnz_template(TaskContext& context)
     inputs[1],
     inputs[2],
     inputs[3],
-    context.scalars()[0].value<uint64_t>(),
   };
   index_type_dispatch(args.B_crd.code(), SpGEMMCSRxCSRxCSRNNZImpl<KIND>{}, args);
 }
@@ -112,7 +111,6 @@ static void spgemm_csr_csr_csr_template(TaskContext& context)
     inputs[3],
     inputs[4],
     inputs[5],
-    context.scalars()[0].value<uint64_t>(),
   };
   index_type_value_type_dispatch(
     args.A_crd.code(), args.A_vals.code(), SpGEMMCSRxCSRxCSRImpl<KIND>{}, args);


### PR DESCRIPTION
This commit fixes the weak scaling (and performance) of the SpGEMM operation by not having it always allocote buffers of the (unpartitioned) matrix size.

Signed-off-by: Rohan Yadav <rohany@alumni.cmu.edu>