### PR TITLE
sparse,src/sparse/array/conv: scale allocations in sorted_coords_to_counts

### DIFF
--- a/sparse/coo.py
+++ b/sparse/coo.py
@@ -48,7 +48,7 @@
 import cunumeric
 import numpy
 import scipy
-from legate.core import Rect, types
+from legate.core import Rect
 from legate.core.launcher import TaskLauncher
 from legate.core.partition import Broadcast, DomainPartition, Tiling
 from legate.core.shape import Shape
@@ -317,7 +317,6 @@ class coo_array(CompressedBase):
             ),
             ReductionOp.ADD,
         )
-        task.add_scalar_arg(self.shape[0], types.int64)
         task.execute()
         # TODO (rohany): On small inputs, it appears that I get a
         #  non-deterministic failure, which appears either as a segfault or an
@@ -432,7 +431,6 @@ class coo_array(CompressedBase):
             ),
             ReductionOp.ADD,
         )
-        task.add_scalar_arg(self.shape[1], types.int64)
         task.execute()
 
         pos, _ = self.nnz_to_pos(q_nnz)

--- a/sparse/quantum.py
+++ b/sparse/quantum.py
@@ -535,7 +535,6 @@ def raw_create_csr(rows, cols, vals, shape, dtype):
         ),
         ReductionOp.ADD,
     )
-    task.add_scalar_arg(shape[0], types.int64)
     task.execute()
     # TODO (rohany): On small inputs, it appears that I get a non-deterministic
     # failure, which appears either as a segfault or an incorrect output. This

--- a/src/sparse/array/conv/sorted_coords_to_counts.cc
+++ b/src/sparse/array/conv/sorted_coords_to_counts.cc
@@ -25,7 +25,7 @@ using namespace legate;
 template <LegateTypeCode INDEX_CODE, typename ACC>
 struct SortedCoordsToCountsImplBody<VariantKind::CPU, INDEX_CODE, ACC> {
   using INDEX_TY = legate_type_of<INDEX_CODE>;
-  void operator()(ACC out, AccessorRO<INDEX_TY, 1> in, int64_t max_vals, const Domain& dom)
+  void operator()(ACC out, AccessorRO<INDEX_TY, 1> in, const Domain& dom)
   {
     for (PointInDomainIterator<1> itr(dom); itr(); itr++) { out[in[*itr]] <<= 1; }
   }

--- a/src/sparse/array/conv/sorted_coords_to_counts.h
+++ b/src/sparse/array/conv/sorted_coords_to_counts.h
@@ -25,7 +25,6 @@ namespace sparse {
 struct SortedCoordsToCountsArgs {
   const legate::Store& output;
   const legate::Store& input;
-  const int64_t max_vals;
 };
 
 class SortedCoordsToCounts : public SparseTask<SortedCoordsToCounts> {

--- a/src/sparse/array/conv/sorted_coords_to_counts_template.inl
+++ b/src/sparse/array/conv/sorted_coords_to_counts_template.inl
@@ -38,7 +38,7 @@ struct SortedCoordsToCountsImpl {
     auto input     = args.input.read_accessor<INDEX_TY, 1>();
     if (args.output.domain().empty() || args.input.domain().empty()) return;
     SortedCoordsToCountsImplBody<KIND, INDEX_CODE, decltype(output)>()(
-      output, input, args.max_vals, args.input.domain());
+      output, input, args.input.domain());
   }
 };
 
@@ -48,7 +48,6 @@ static void sorted_coords_to_counts_template(TaskContext& context)
   SortedCoordsToCountsArgs args{
     context.reductions()[0],
     context.inputs()[0],
-    context.scalars()[0].value<int64_t>(),
   };
   index_type_dispatch(args.input.code(), SortedCoordsToCountsImpl<KIND>{}, args);
 }


### PR DESCRIPTION
This commit makes sorted_coords_to_counts actually weak scale by having it not allocate the full dimension value in deferred buffer space.

Signed-off-by: Rohan Yadav <rohany@alumni.cmu.edu>