### PR TITLE
Adding ndim attribute to csc

### DIFF
--- a/sparse/csc.py
+++ b/sparse/csc.py
@@ -77,6 +77,8 @@ from .utils import (
 @clone_scipy_arr_kind(scipy.sparse.csc_array)
 class csc_array(CompressedBase, DenseSparseBase):
     def __init__(self, arg, shape=None, dtype=None, copy=False):
+
+        self.ndim = 2
         super().__init__()
 
         if isinstance(arg, numpy.ndarray):

--- a/sparse/csc.py
+++ b/sparse/csc.py
@@ -77,7 +77,6 @@ from .utils import (
 @clone_scipy_arr_kind(scipy.sparse.csc_array)
 class csc_array(CompressedBase, DenseSparseBase):
     def __init__(self, arg, shape=None, dtype=None, copy=False):
-
         self.ndim = 2
         super().__init__()
 


### PR DESCRIPTION
This is a very trivial change to add the `ndim` attribute to `csc_array`.  Note that this attribute is defined in `csr_array` already but wasn't added to `csc`. 